### PR TITLE
Added return type on typescript defs for enc/dec of Base64

### DIFF
--- a/dist/secure-ls.d.ts
+++ b/dist/secure-ls.d.ts
@@ -35,7 +35,7 @@ declare class SecureLS {
 declare namespace SecureLS{
     interface Base64 {
         _keyStr: string;
-        encode(e: string);
-        decode(e: string);
+        encode(e: string): string;
+        decode(e: string): string;
     }
 }


### PR DESCRIPTION
Added return type of `string` to encode/decode of `Base64`, because missing return type causes error on compilation of Typescript.